### PR TITLE
Fix: expose moment methods as hash properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,11 +48,17 @@ module.exports = function dateHelper(str, pattern, options) {
     var res = moment(str);
     for (var key in options.hash) {
       if (typeof res[key] === 'function') {
-        return res[key](options.hash[key]);
+        if (key==="format") {
+          continue;
+        }
+
+        res = res[key](options.hash[key]);
       } else {
         console.error('moment.js does not support "' + key + '"');
       }
     }
+
+    return res.format(options.hash['format']);
   }
 
   if (utils.isObject(str)) {


### PR DESCRIPTION
I'm not 100% certain this is right, but: in my experience helper-date calls nothing but "format" and immediately returns the results, without calling additional moment methods first. This should help address that, but likely needs additional testing.